### PR TITLE
[with-niconicomments] 短縮リンク(nico.ms)をサポート

### DIFF
--- a/userscript/youtube/with-niconicomments.user.js
+++ b/userscript/youtube/with-niconicomments.user.js
@@ -51,9 +51,13 @@ function getURLsFromDescription(descriptionElement) {
  * @returns string | null
  */
 function findNiconicoUrl(urlArray) {
-    const niconicoURL = urlArray.find((url) => url.includes("www.nicovideo.jp"));
+    const niconicoURL = urlArray.find((url) => url.includes("www.nicovideo.jp") || url.includes("nico.ms"));
     if (!niconicoURL) {
         return null;
+    }
+    const nicoms = niconicoURL.match(/nico\.ms\/((?:sm|nm|so)?\d+)/);
+    if (nicoms){
+        return `https://www.nicovideo.jp/watch/${nicoms[1]}`;
     }
     return niconicoURL;
 }


### PR DESCRIPTION
https://www.youtube.com/watch?v=dzgqDgHcP7w
上記の動画の様にリンクに www.nicovideo.jp ではなく nico.ms を使用しているものを見かけたため対応を行いました
nico.ms だった場合、バックエンド側が対応していなさそうだったため www.nicovideo.jp の形式に変換して返しています